### PR TITLE
Session/3 StatefulWidget のライフサイクル

### DIFF
--- a/lib/green_panel.dart
+++ b/lib/green_panel.dart
@@ -1,0 +1,12 @@
+import 'package:flutter/material.dart';
+
+class GreenPanel extends StatelessWidget {
+  const GreenPanel({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return const ColoredBox(
+      color: Colors.green,
+    );
+  }
+}

--- a/lib/loading_view.dart
+++ b/lib/loading_view.dart
@@ -1,0 +1,40 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter/scheduler.dart';
+import 'package:flutter_training/green_panel.dart';
+import 'package:flutter_training/screen.dart';
+
+class LoadingView extends StatefulWidget {
+  const LoadingView({super.key});
+
+  @override
+  State<StatefulWidget> createState() => _LoadingViewState();
+}
+
+class _LoadingViewState extends State<LoadingView> {
+  Future<void> transition() async {
+    await SchedulerBinding.instance.endOfFrame;
+
+    await Future<void>.delayed(const Duration(milliseconds: 500));
+
+    if (!context.mounted) {
+      return;
+    }
+
+    await Navigator.pushNamed(context, Screen.weatherScreen.route);
+
+    unawaited(transition());
+  }
+
+  @override
+  void initState() {
+    super.initState();
+    unawaited(transition());
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return const GreenPanel();
+  }
+}

--- a/lib/loading_view.dart
+++ b/lib/loading_view.dart
@@ -18,7 +18,7 @@ class _LoadingViewState extends State<LoadingView> {
 
     await Future<void>.delayed(const Duration(milliseconds: 500));
 
-    if (!context.mounted) {
+    if (!mounted) {
       return;
     }
 

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -13,11 +13,11 @@ class MainApp extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
-      home: const LoadingView(),
       routes: {
-        Screen.launch.route: (context) => const LoadingView(),
+        Screen.loading.route: (context) => const LoadingView(),
         Screen.weatherScreen.route: (context) => const WeatherScreen(),
       },
+      initialRoute: Screen.loading.route,
     );
   }
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,4 +1,6 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_training/loading_view.dart';
+import 'package:flutter_training/screen.dart';
 import 'package:flutter_training/weather/weather_screen.dart';
 
 void main() {
@@ -10,6 +12,12 @@ class MainApp extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return const MaterialApp(home: WeatherScreen());
+    return MaterialApp(
+      home: const LoadingView(),
+      routes: {
+        Screen.launch.route: (context) => const LoadingView(),
+        Screen.weatherScreen.route: (context) => const WeatherScreen(),
+      },
+    );
   }
 }

--- a/lib/screen.dart
+++ b/lib/screen.dart
@@ -1,5 +1,5 @@
 enum Screen {
-  launch(route: '/launch'),
+  loading(route: '/loading'),
   weatherScreen(route: '/weather_screen');
 
   const Screen({

--- a/lib/screen.dart
+++ b/lib/screen.dart
@@ -1,0 +1,10 @@
+enum Screen {
+  launch(route: '/launch'),
+  weatherScreen(route: '/weather_screen');
+
+  const Screen({
+    required this.route,
+  });
+
+  final String route;
+}

--- a/lib/weather/weather_screen.dart
+++ b/lib/weather/weather_screen.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_training/green_panel.dart';
 import 'package:flutter_training/weather/weather_panel.dart';
 import 'package:yumemi_weather/yumemi_weather.dart';
 
@@ -67,7 +68,27 @@ class _Buttons extends StatelessWidget {
           child: Center(
             child: TextButton(
               // 後で関数にしたい
-              onPressed: () {},
+              onPressed: () async {
+                await Navigator.of(context).push<void>(
+                  PageRouteBuilder(
+                    pageBuilder: (context, animation, secondaryAnimation) {
+                      return const GreenPanel();
+                    },
+                    transitionsBuilder:
+                        (context, animation, secondaryAnimation, child) {
+                      const begin = Offset(-1, 0);
+                      const end = Offset.zero;
+                      final tween = Tween(begin: begin, end: end)
+                          .chain(CurveTween(curve: Curves.easeInOut));
+                      final offsetAnimation = animation.drive(tween);
+                      return SlideTransition(
+                        position: offsetAnimation,
+                        child: child,
+                      );
+                    },
+                  ),
+                );
+              },
               child: const Text('Close'),
             ),
           ),

--- a/lib/weather/weather_screen.dart
+++ b/lib/weather/weather_screen.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_training/green_panel.dart';
 import 'package:flutter_training/weather/weather_panel.dart';
 import 'package:yumemi_weather/yumemi_weather.dart';
 
@@ -20,25 +19,8 @@ class _WeatherScreen extends State<WeatherScreen> {
     });
   }
 
-  Future<void> _closeWeatherScreen() async {
-    await Navigator.of(context).push<void>(
-      PageRouteBuilder(
-        pageBuilder: (context, animation, secondaryAnimation) {
-          return const GreenPanel();
-        },
-        transitionsBuilder: (context, animation, secondaryAnimation, child) {
-          const begin = Offset(-1, 0);
-          const end = Offset.zero;
-          final tween = Tween(begin: begin, end: end)
-              .chain(CurveTween(curve: Curves.easeInOut));
-          final offsetAnimation = animation.drive(tween);
-          return SlideTransition(
-            position: offsetAnimation,
-            child: child,
-          );
-        },
-      ),
-    );
+  void _closeWeatherScreen() {
+    Navigator.pop(context);
   }
 
   @override
@@ -92,7 +74,6 @@ class _Buttons extends StatelessWidget {
           width: textWidth,
           child: Center(
             child: TextButton(
-              // 後で関数にしたい
               onPressed: _onClose,
               child: const Text('Close'),
             ),

--- a/lib/weather/weather_screen.dart
+++ b/lib/weather/weather_screen.dart
@@ -20,6 +20,27 @@ class _WeatherScreen extends State<WeatherScreen> {
     });
   }
 
+  Future<void> _closeWeatherScreen() async {
+    await Navigator.of(context).push<void>(
+      PageRouteBuilder(
+        pageBuilder: (context, animation, secondaryAnimation) {
+          return const GreenPanel();
+        },
+        transitionsBuilder: (context, animation, secondaryAnimation, child) {
+          const begin = Offset(-1, 0);
+          const end = Offset.zero;
+          final tween = Tween(begin: begin, end: end)
+              .chain(CurveTween(curve: Curves.easeInOut));
+          final offsetAnimation = animation.drive(tween);
+          return SlideTransition(
+            position: offsetAnimation,
+            child: child,
+          );
+        },
+      ),
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
@@ -38,6 +59,7 @@ class _WeatherScreen extends State<WeatherScreen> {
                   children: [
                     const SizedBox(height: 80),
                     _Buttons(
+                      onClose: _closeWeatherScreen,
                       onReloaded: _reloadWeatherCondition,
                     ),
                   ],
@@ -54,8 +76,11 @@ class _WeatherScreen extends State<WeatherScreen> {
 class _Buttons extends StatelessWidget {
   const _Buttons({
     required void Function() onReloaded,
-  }) : _onReloaded = onReloaded;
+    required void Function() onClose,
+  })  : _onReloaded = onReloaded,
+        _onClose = onClose;
   final VoidCallback _onReloaded;
+  final VoidCallback _onClose;
   @override
   Widget build(BuildContext context) {
     final screenSize = MediaQuery.sizeOf(context);
@@ -68,27 +93,7 @@ class _Buttons extends StatelessWidget {
           child: Center(
             child: TextButton(
               // 後で関数にしたい
-              onPressed: () async {
-                await Navigator.of(context).push<void>(
-                  PageRouteBuilder(
-                    pageBuilder: (context, animation, secondaryAnimation) {
-                      return const GreenPanel();
-                    },
-                    transitionsBuilder:
-                        (context, animation, secondaryAnimation, child) {
-                      const begin = Offset(-1, 0);
-                      const end = Offset.zero;
-                      final tween = Tween(begin: begin, end: end)
-                          .chain(CurveTween(curve: Curves.easeInOut));
-                      final offsetAnimation = animation.drive(tween);
-                      return SlideTransition(
-                        position: offsetAnimation,
-                        child: child,
-                      );
-                    },
-                  ),
-                );
-              },
+              onPressed: _onClose,
               child: const Text('Close'),
             ),
           ),

--- a/lib/weather/weather_screen.dart
+++ b/lib/weather/weather_screen.dart
@@ -42,7 +42,7 @@ class _WeatherScreen extends State<WeatherScreen> {
                     const SizedBox(height: 80),
                     _Buttons(
                       onClose: _closeWeatherScreen,
-                      onReloaded: _reloadWeatherCondition,
+                      onReload: _reloadWeatherCondition,
                     ),
                   ],
                 ),
@@ -57,11 +57,11 @@ class _WeatherScreen extends State<WeatherScreen> {
 
 class _Buttons extends StatelessWidget {
   const _Buttons({
-    required void Function() onReloaded,
+    required void Function() onReload,
     required void Function() onClose,
-  })  : _onReloaded = onReloaded,
+  })  : _onReload = onReload,
         _onClose = onClose;
-  final VoidCallback _onReloaded;
+  final VoidCallback _onReload;
   final VoidCallback _onClose;
   @override
   Widget build(BuildContext context) {
@@ -83,7 +83,7 @@ class _Buttons extends StatelessWidget {
           width: textWidth,
           child: Center(
             child: TextButton(
-              onPressed: _onReloaded,
+              onPressed: _onReload,
               child: const Text('Reload'),
             ),
           ),


### PR DESCRIPTION
## 課題

close #4 

## 対応箇所
<!--
課題のどこに対応したか１つ１つ確認しましょう。
-->
- [x] [StatefulWidget](https://api.flutter.dev/flutter/widgets/StatefulWidget-class.html) を継承した Widget で構築された新しい画面を追加する
- [x] 新しい画面の背景色は [Colors.green](https://api.flutter.dev/flutter/material/Colors/green-constant.html) に設定する
- [x] アプリ起動時に新しい画面に遷移する
- [x] 新しい画面が表示されたら、0.5 秒後に前回まで作っていた画面に遷移する
- [x] 前回まで作っていた画面の Close ボタンをタップすると画面を閉じる

## 動作

<!--
画像や動画を添付しましょう。
動作に変更なければ、必要ありません。
-->

| expected | actual(iOS) | actual(Android) |
|----------|--------|--------|
| ![demo_session3](https://github.com/yumemi-ymorii/flutter-training/assets/126639057/58587ef8-7873-4a82-989d-8013ded310a0) |  ![flutter-training_session3_iOS](https://github.com/yumemi-ymorii/flutter-training/assets/126639057/c6e2bce8-8e72-46bd-b75b-76a0be7e4ad0) | ![flutter-training_session3_Android](https://github.com/yumemi-ymorii/flutter-training/assets/126639057/c97549f6-03b8-47ec-bda3-04d6b3a73790)|
