### PR TITLE
Session/5 API のエラーハンドリング

### DIFF
--- a/lib/weather/weather_alert_dialog.dart
+++ b/lib/weather/weather_alert_dialog.dart
@@ -1,0 +1,21 @@
+import 'package:flutter/material.dart';
+
+class WeatherAlertDialog extends StatelessWidget {
+  const WeatherAlertDialog({required String errorMessage, super.key})
+      : _errorMessage = errorMessage;
+  final String _errorMessage;
+
+  @override
+  Widget build(BuildContext context) {
+    return AlertDialog(
+      title: const Text('Reloading Weather Info Error'),
+      content: Text(_errorMessage),
+      actions: <Widget>[
+        TextButton(
+          onPressed: () => Navigator.pop(context, 'OK'),
+          child: const Text('OK'),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/weather/weather_alert_dialog.dart
+++ b/lib/weather/weather_alert_dialog.dart
@@ -12,7 +12,7 @@ class WeatherAlertDialog extends StatelessWidget {
       content: Text(_errorMessage),
       actions: <Widget>[
         TextButton(
-          onPressed: () => Navigator.pop(context, 'OK'),
+          onPressed: () => Navigator.pop(context),
           child: const Text('OK'),
         ),
       ],

--- a/lib/weather/weather_condition.dart
+++ b/lib/weather/weather_condition.dart
@@ -1,0 +1,5 @@
+enum WeatherCondition {
+  sunny,
+  cloudy,
+  rainy,
+}

--- a/lib/weather/weather_icon.dart
+++ b/lib/weather/weather_icon.dart
@@ -1,15 +1,16 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/flutter_svg.dart';
+import 'package:flutter_training/weather/weather_condition.dart';
 
 class WeatherIcon extends StatelessWidget {
-  const WeatherIcon({required String weatherCondition, super.key})
+  const WeatherIcon({required WeatherCondition weatherCondition, super.key})
       : _weatherCondition = weatherCondition;
-  final String _weatherCondition;
+  final WeatherCondition _weatherCondition;
 
   @override
   Widget build(BuildContext context) {
     return SvgPicture.asset(
-      'assets/$_weatherCondition.svg',
+      'assets/${_weatherCondition.name}.svg',
     );
   }
 }

--- a/lib/weather/weather_panel.dart
+++ b/lib/weather/weather_panel.dart
@@ -1,12 +1,13 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_training/weather/weather_condition.dart';
 import 'package:flutter_training/weather/weather_icon.dart';
 
 class WeatherPanel extends StatelessWidget {
   const WeatherPanel({
     super.key,
-    String? weatherCondition,
+    WeatherCondition? weatherCondition,
   }) : _weatherCondition = weatherCondition;
-  final String? _weatherCondition;
+  final WeatherCondition? _weatherCondition;
 
   @override
   Widget build(BuildContext context) {
@@ -15,7 +16,7 @@ class WeatherPanel extends StatelessWidget {
 
     final weatherIcon = switch (_weatherCondition) {
       null => const Placeholder(),
-      final String value => WeatherIcon(weatherCondition: value),
+      final WeatherCondition value => WeatherIcon(weatherCondition: value),
     };
 
     final temperatureTextGroup = Row(

--- a/lib/weather/weather_screen.dart
+++ b/lib/weather/weather_screen.dart
@@ -24,13 +24,7 @@ class _WeatherScreen extends State<WeatherScreen> {
       if (!expectedWeathers.contains(weatherCodition)) {
         const errorMessage = '予期しない天気が取得されました。'
             '時間を置いてもエラーが発生する場合はお問い合わせお願いいたします。';
-        unawaited(
-          showDialog<String>(
-            context: context,
-            builder: (context) =>
-                const WeatherAlertDialog(errorMessage: errorMessage),
-          ),
-        );
+        showWeatherAlertDialog(errorMessage);
       }
 
       setState(() {
@@ -42,17 +36,24 @@ class _WeatherScreen extends State<WeatherScreen> {
         YumemiWeatherError.unknown => '予期せぬエラーが発生しております。'
             '時間を置いてもエラーが発生する場合はお問い合わせお願いいたします。',
       };
-      unawaited(
-        showDialog<String>(
-          context: context,
-          builder: (context) => WeatherAlertDialog(errorMessage: errorMessage),
-        ),
-      );
+      showWeatherAlertDialog(errorMessage);
     }
   }
 
   void _closeWeatherScreen() {
     Navigator.pop(context);
+  }
+
+  void showWeatherAlertDialog(String errorMessage) {
+    if (!mounted) {
+      return;
+    }
+    unawaited(
+      showDialog<String>(
+        context: context,
+        builder: (context) => WeatherAlertDialog(errorMessage: errorMessage),
+      ),
+    );
   }
 
   @override

--- a/lib/weather/weather_screen.dart
+++ b/lib/weather/weather_screen.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
 import 'package:flutter/material.dart';
+import 'package:flutter_training/weather/weather_alert_dialog.dart';
 import 'package:flutter_training/weather/weather_panel.dart';
 import 'package:yumemi_weather/yumemi_weather.dart';
 
@@ -31,16 +32,7 @@ class _WeatherScreen extends State<WeatherScreen> {
       unawaited(
         showDialog<String>(
           context: context,
-          builder: (context) => AlertDialog(
-            title: const Text('Reloading Weather Info Error'),
-            content: Text(errorMessage),
-            actions: <Widget>[
-              TextButton(
-                onPressed: () => Navigator.pop(context, 'OK'),
-                child: const Text('OK'),
-              ),
-            ],
-          ),
+          builder: (context) => WeatherAlertDialog(errorMessage: errorMessage),
         ),
       );
     }

--- a/lib/weather/weather_screen.dart
+++ b/lib/weather/weather_screen.dart
@@ -3,14 +3,9 @@ import 'package:collection/collection.dart';
 
 import 'package:flutter/material.dart';
 import 'package:flutter_training/weather/weather_alert_dialog.dart';
+import 'package:flutter_training/weather/weather_condition.dart';
 import 'package:flutter_training/weather/weather_panel.dart';
 import 'package:yumemi_weather/yumemi_weather.dart';
-
-enum WeatherCondition {
-  sunny,
-  cloudy,
-  rainy,
-}
 
 class WeatherScreen extends StatefulWidget {
   const WeatherScreen({super.key});
@@ -20,7 +15,7 @@ class WeatherScreen extends StatefulWidget {
 }
 
 class _WeatherScreen extends State<WeatherScreen> {
-  String? _weatherCodition;
+  WeatherCondition? _weatherCodition;
 
   void _reloadWeatherCondition() {
     const location = 'tokyoß';
@@ -34,10 +29,10 @@ class _WeatherScreen extends State<WeatherScreen> {
       if (weatherCondition == null) {
         const errorMessage = '予期しない天気が取得されました。'
             '時間を置いてもエラーが発生する場合はお問い合わせお願いいたします。';
-        showWeatherAlertDialog(errorMessage);
+        _showWeatherAlertDialog(errorMessage);
       }
       setState(() {
-        _weatherCodition = weatherCondition?.name;
+        _weatherCodition = weatherCondition;
       });
     } on YumemiWeatherError catch (e) {
       final errorMessage = switch (e) {
@@ -45,7 +40,7 @@ class _WeatherScreen extends State<WeatherScreen> {
         YumemiWeatherError.unknown => '予期せぬエラーが発生しております。'
             '時間を置いてもエラーが発生する場合はお問い合わせお願いいたします。',
       };
-      showWeatherAlertDialog(errorMessage);
+      _showWeatherAlertDialog(errorMessage);
     }
   }
 
@@ -53,7 +48,7 @@ class _WeatherScreen extends State<WeatherScreen> {
     Navigator.pop(context);
   }
 
-  void showWeatherAlertDialog(String errorMessage) {
+  void _showWeatherAlertDialog(String errorMessage) {
     if (!mounted) {
       return;
     }

--- a/lib/weather/weather_screen.dart
+++ b/lib/weather/weather_screen.dart
@@ -1,9 +1,16 @@
 import 'dart:async';
+import 'package:collection/collection.dart';
 
 import 'package:flutter/material.dart';
 import 'package:flutter_training/weather/weather_alert_dialog.dart';
 import 'package:flutter_training/weather/weather_panel.dart';
 import 'package:yumemi_weather/yumemi_weather.dart';
+
+enum WeatherCondition {
+  sunny,
+  cloudy,
+  rainy,
+}
 
 class WeatherScreen extends StatefulWidget {
   const WeatherScreen({super.key});
@@ -18,17 +25,19 @@ class _WeatherScreen extends State<WeatherScreen> {
   void _reloadWeatherCondition() {
     const location = 'tokyoß';
     final yumemiWeather = YumemiWeather();
-    const expectedWeathers = <String>['sunny', 'cloudy', 'rainy'];
     try {
-      final weatherCodition = yumemiWeather.fetchThrowsWeather(location);
-      if (!expectedWeathers.contains(weatherCodition)) {
+      final weatherCoditionText = yumemiWeather.fetchThrowsWeather(location);
+      final weatherCondition = WeatherCondition.values.firstWhereOrNull(
+        (w) => w.name == weatherCoditionText,
+      );
+
+      if (weatherCondition == null) {
         const errorMessage = '予期しない天気が取得されました。'
             '時間を置いてもエラーが発生する場合はお問い合わせお願いいたします。';
         showWeatherAlertDialog(errorMessage);
       }
-
       setState(() {
-        _weatherCodition = weatherCodition;
+        _weatherCodition = weatherCondition?.name;
       });
     } on YumemiWeatherError catch (e) {
       final errorMessage = switch (e) {

--- a/lib/weather/weather_screen.dart
+++ b/lib/weather/weather_screen.dart
@@ -18,8 +18,21 @@ class _WeatherScreen extends State<WeatherScreen> {
   void _reloadWeatherCondition() {
     const location = 'tokyoß';
     final yumemiWeather = YumemiWeather();
+    const expectedWeathers = <String>['sunny', 'cloudy', 'rainy'];
     try {
       final weatherCodition = yumemiWeather.fetchThrowsWeather(location);
+      if (!expectedWeathers.contains(weatherCodition)) {
+        const errorMessage = '予期しない天気が取得されました。'
+            '時間を置いてもエラーが発生する場合はお問い合わせお願いいたします。';
+        unawaited(
+          showDialog<String>(
+            context: context,
+            builder: (context) =>
+                const WeatherAlertDialog(errorMessage: errorMessage),
+          ),
+        );
+      }
+
       setState(() {
         _weatherCodition = weatherCodition;
       });

--- a/lib/weather/weather_screen.dart
+++ b/lib/weather/weather_screen.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_training/weather/weather_panel.dart';
 import 'package:yumemi_weather/yumemi_weather.dart';
@@ -13,10 +15,35 @@ class _WeatherScreen extends State<WeatherScreen> {
   String? _weatherCodition;
 
   void _reloadWeatherCondition() {
+    const location = 'tokyoß';
     final yumemiWeather = YumemiWeather();
-    setState(() {
-      _weatherCodition = yumemiWeather.fetchSimpleWeather();
-    });
+    try {
+      final weatherCodition = yumemiWeather.fetchThrowsWeather(location);
+      setState(() {
+        _weatherCodition = weatherCodition;
+      });
+    } on YumemiWeatherError catch (e) {
+      final errorMessage = switch (e) {
+        YumemiWeatherError.invalidParameter => '「$location」は無効な地域名です',
+        YumemiWeatherError.unknown => '予期せぬエラーが発生しております。'
+            '時間を置いてもエラーが発生する場合はお問い合わせお願いいたします。',
+      };
+      unawaited(
+        showDialog<String>(
+          context: context,
+          builder: (context) => AlertDialog(
+            title: const Text('Reloading Weather Info Error'),
+            content: Text(errorMessage),
+            actions: <Widget>[
+              TextButton(
+                onPressed: () => Navigator.pop(context, 'OK'),
+                child: const Text('OK'),
+              ),
+            ],
+          ),
+        ),
+      );
+    }
   }
 
   void _closeWeatherScreen() {

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -42,7 +42,7 @@ packages:
     source: hosted
     version: "1.1.1"
   collection:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: collection
       sha256: ee67cb0715911d28db6bf4af1026078bd6f0128b07a5f66fb2ed94ec6783c09a

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -7,6 +7,7 @@ environment:
   sdk: '>=3.3.4 <4.0.0'
 
 dependencies:
+  collection: ^1.18.0
   flutter:
     sdk: flutter
   flutter_svg: ^2.0.10+1


### PR DESCRIPTION
## 課題
yumemi_weather の API のエラーを補足して、ダイアログを表示

close #6 

## 対応箇所

<!--
課題のどこに対応したか１つ１つ確認しましょう。
-->

- [x] 使用する API を fetchSimpleWeather() から fetchThrowsWeather() に変更する
- [x] API のエラーを補足して、エラーの内容に応じて AlertDialog でメッセージを表示する(メッセージの内容は自由)
- [x] AlertDialog の OK ボタンをタップすると、ダイアログを閉じる

## 動作

<!--
画像や動画を添付しましょう。
動作に変更なければ、必要ありません。
-->

| expected | actual |
|----------|--------|
|  ![flutter_training_sesson5_demo](https://github.com/yumemi-ymorii/flutter-training/assets/126639057/d304bf73-1257-4893-8dac-3bb4bbb8891e)| ![flutter-training_session5_android](https://github.com/yumemi-ymorii/flutter-training/assets/126639057/dbc7aa58-1579-4326-859e-5d463871cc0e) |
