### PR TITLE
Session/11 時間のかかる処理をスレッドブロック

### DIFF
--- a/lib/weather/data/weather_exception.dart
+++ b/lib/weather/data/weather_exception.dart
@@ -2,7 +2,7 @@ sealed class WeatherException implements Exception {}
 
 class InvalidParameterException extends WeatherException {}
 
-class UnkownException extends WeatherException {}
+class UnknownException extends WeatherException {}
 
 class InvalidResponseException extends WeatherException {}
 

--- a/lib/weather/weather_notifier.dart
+++ b/lib/weather/weather_notifier.dart
@@ -15,8 +15,8 @@ class WeatherNotifier extends _$WeatherNotifier {
     return null;
   }
 
-  void fetchWeather(Location location) {
-    final weather = _weatherRepository.fetchWeather(location);
+  Future<void> fetchWeather(Location location) async {
+    final weather = await _weatherRepository.fetchWeather(location);
     state = weather;
   }
 }

--- a/lib/weather/weather_notifier.g.dart
+++ b/lib/weather/weather_notifier.g.dart
@@ -8,7 +8,7 @@ part of 'weather_notifier.dart';
 // RiverpodGenerator
 // **************************************************************************
 
-String _$weatherNotifierHash() => r'823f048a59ff3f328e889101274c291d49dbbfd3';
+String _$weatherNotifierHash() => r'0e6dfacfaead87221f02c0eaba06d0205ff2bb8d';
 
 /// See also [WeatherNotifier].
 @ProviderFor(WeatherNotifier)

--- a/lib/weather/weather_repository.dart
+++ b/lib/weather/weather_repository.dart
@@ -1,5 +1,6 @@
 import 'dart:convert';
 
+import 'package:flutter/foundation.dart';
 import 'package:flutter_training/weather/data/weather_exception.dart';
 import 'package:flutter_training/weather/location.dart';
 import 'package:flutter_training/weather/weather.dart';
@@ -19,12 +20,13 @@ class WeatherRepository {
       : _weatherApi = weatherApi;
 
   final YumemiWeather _weatherApi;
-  Weather fetchWeather(Location location) {
+  Future<Weather> fetchWeather(Location location) async {
     final locationJson = location.toJson();
     final locationJsonString = jsonEncode(locationJson);
 
     try {
-      final weatherText = _weatherApi.syncFetchWeather(locationJsonString);
+      final weatherText =
+          await compute(_weatherApi.syncFetchWeather, locationJsonString);
       return switch (jsonDecode(weatherText)) {
         final Map<String, dynamic> weatherMap => Weather.fromJson(weatherMap),
         _ => throw InvalidResponseException(),

--- a/lib/weather/weather_repository.dart
+++ b/lib/weather/weather_repository.dart
@@ -24,7 +24,7 @@ class WeatherRepository {
     final locationJsonString = jsonEncode(locationJson);
 
     try {
-      final weatherText = _weatherApi.fetchWeather(locationJsonString);
+      final weatherText = _weatherApi.syncFetchWeather(locationJsonString);
       return switch (jsonDecode(weatherText)) {
         final Map<String, dynamic> weatherMap => Weather.fromJson(weatherMap),
         _ => throw InvalidResponseException(),

--- a/lib/weather/weather_repository.dart
+++ b/lib/weather/weather_repository.dart
@@ -34,7 +34,7 @@ class WeatherRepository {
     } on YumemiWeatherError catch (e) {
       final weatherException = switch (e) {
         YumemiWeatherError.invalidParameter => InvalidParameterException(),
-        YumemiWeatherError.unknown => UnkownException(),
+        YumemiWeatherError.unknown => UnknownException(),
       };
       throw weatherException;
     } on FormatException catch (_) {

--- a/lib/weather/weather_screen.dart
+++ b/lib/weather/weather_screen.dart
@@ -16,14 +16,14 @@ class WeatherScreen extends ConsumerStatefulWidget {
 }
 
 class _WeatherScreen extends ConsumerState<WeatherScreen> {
-  void _reloadWeatherCondition() {
+  Future<void> _reloadWeatherCondition() async {
     final location = Location(
       area: 'tokyo',
       date: DateTime.parse('2020-04-01T12:00:00+09:00'),
     );
 
     try {
-      ref.read(weatherNotifierProvider.notifier).fetchWeather(location);
+      await ref.read(weatherNotifierProvider.notifier).fetchWeather(location);
     } on WeatherException catch (e) {
       final errorMessage = switch (e) {
         InvalidParameterException() => '「${location.area}」は無効な地域名です',

--- a/lib/weather/weather_screen.dart
+++ b/lib/weather/weather_screen.dart
@@ -16,7 +16,7 @@ class WeatherScreen extends ConsumerStatefulWidget {
 }
 
 class _WeatherScreen extends ConsumerState<WeatherScreen> {
-  bool shouldShowIndicator = false;
+  bool _shouldShowIndicator = false;
   Future<void> _reloadWeatherCondition() async {
     final location = Location(
       area: 'tokyo',
@@ -24,7 +24,7 @@ class _WeatherScreen extends ConsumerState<WeatherScreen> {
     );
     try {
       setState(() {
-        shouldShowIndicator = true;
+        _shouldShowIndicator = true;
       });
       await ref.read(weatherNotifierProvider.notifier).fetchWeather(location);
     } on WeatherException catch (e) {
@@ -48,7 +48,7 @@ class _WeatherScreen extends ConsumerState<WeatherScreen> {
       _showWeatherAlertDialog(errorMessage);
     } finally {
       setState(() {
-        shouldShowIndicator = false;
+        _shouldShowIndicator = false;
       });
     }
   }
@@ -100,7 +100,7 @@ class _WeatherScreen extends ConsumerState<WeatherScreen> {
       children: [
         page,
         Visibility(
-          visible: shouldShowIndicator,
+          visible: _shouldShowIndicator,
           child: const SizedBox.expand(
             child: ColoredBox(
               color: Colors.black54,

--- a/lib/weather/weather_screen.dart
+++ b/lib/weather/weather_screen.dart
@@ -30,7 +30,7 @@ class _WeatherScreen extends ConsumerState<WeatherScreen> {
     } on WeatherException catch (e) {
       final errorMessage = switch (e) {
         InvalidParameterException() => '「${location.area}」は無効な地域名です',
-        UnkownException() => '予期せぬエラーが発生しております。'
+        UnknownException() => '予期せぬエラーが発生しております。'
             '時間を置いてもエラーが発生する場合はお問い合わせお願いいたします。',
         InvalidResponseException() => '予期せぬエラーが発生しております。'
             '時間を置いてもエラーが発生する場合はお問い合わせお願いいたします。',

--- a/lib/weather/weather_screen.dart
+++ b/lib/weather/weather_screen.dart
@@ -16,13 +16,16 @@ class WeatherScreen extends ConsumerStatefulWidget {
 }
 
 class _WeatherScreen extends ConsumerState<WeatherScreen> {
+  bool shouldShowIndicator = false;
   Future<void> _reloadWeatherCondition() async {
     final location = Location(
       area: 'tokyo',
       date: DateTime.parse('2020-04-01T12:00:00+09:00'),
     );
-
     try {
+      setState(() {
+        shouldShowIndicator = true;
+      });
       await ref.read(weatherNotifierProvider.notifier).fetchWeather(location);
     } on WeatherException catch (e) {
       final errorMessage = switch (e) {
@@ -43,6 +46,10 @@ class _WeatherScreen extends ConsumerState<WeatherScreen> {
       const errorMessage = '予期しない天気が取得されました。'
           '時間を置いてもエラーが発生する場合はお問い合わせお願いいたします。';
       _showWeatherAlertDialog(errorMessage);
+    } finally {
+      setState(() {
+        shouldShowIndicator = false;
+      });
     }
   }
 
@@ -64,7 +71,7 @@ class _WeatherScreen extends ConsumerState<WeatherScreen> {
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
+    final page = Scaffold(
       body: SizedBox.expand(
         child: FractionallySizedBox(
           widthFactor: 0.5,
@@ -88,6 +95,20 @@ class _WeatherScreen extends ConsumerState<WeatherScreen> {
           ),
         ),
       ),
+    );
+    return Stack(
+      children: [
+        page,
+        Visibility(
+          visible: shouldShowIndicator,
+          child: const SizedBox.expand(
+            child: ColoredBox(
+              color: Colors.black54,
+              child: Center(child: CircularProgressIndicator()),
+            ),
+          ),
+        ),
+      ],
     );
   }
 }

--- a/test/weather_panel_widget_test.dart
+++ b/test/weather_panel_widget_test.dart
@@ -84,6 +84,8 @@ void main() {
         expect(find.svg(asset.bytesLoader), findsOneWidget);
         expect(find.text('100℃'), findsOneWidget);
         expect(find.text('0℃'), findsOneWidget);
+        // インジケータが消えているか
+        expect(find.byType(CircularProgressIndicator), findsNothing);
       });
     }
   });
@@ -156,6 +158,8 @@ void main() {
         await tester.pumpAndSettle();
 
         expect(find.byType(AlertDialog), findsNothing);
+        // インジケータが消えているか
+        expect(find.byType(CircularProgressIndicator), findsNothing);
       }
     });
   });

--- a/test/weather_panel_widget_test.dart
+++ b/test/weather_panel_widget_test.dart
@@ -61,7 +61,9 @@ void main() {
         );
         setUp(tester);
 
-        when(mockWeatherRepository.fetchWeather(any)).thenReturn(weather);
+        when(mockWeatherRepository.fetchWeather(any)).thenAnswer(
+          (_) async => weather,
+        );
 
         await tester.pumpWidget(
           ProviderScope(

--- a/test/weather_panel_widget_test.dart
+++ b/test/weather_panel_widget_test.dart
@@ -136,7 +136,9 @@ void main() {
     ];
 
     for (final (exception, errorMessage) in errorCases) {
-      testWidgets('エラーダイアログ', (tester) async {
+      testWidgets(
+          '''${exception.runtimeType}がスローされた場合にダイアログで "$errorMessage" という文言が表示される''',
+          (tester) async {
         setUp(tester);
 
         final completer = Completer<Weather>();

--- a/test/weather_panel_widget_test.dart
+++ b/test/weather_panel_widget_test.dart
@@ -135,7 +135,10 @@ void main() {
       ];
 
       for (final (exception, errorMessage) in errorCases) {
-        when(mockWeatherRepository.fetchWeather(any)).thenThrow(exception);
+        final completer = Completer<Weather>();
+        when(mockWeatherRepository.fetchWeather(any)).thenAnswer(
+          (_) => completer.future,
+        );
 
         await tester.pumpWidget(
           ProviderScope(
@@ -152,6 +155,13 @@ void main() {
 
         //  Reloadを押下して描画完了まで待機
         await tester.tap(find.text('Reload'));
+        await tester.pump();
+
+        // インジケータが表示されているか
+        expect(find.byType(CircularProgressIndicator), findsOneWidget);
+
+        // 非同期処理を完了
+        completer.completeError(exception);
         await tester.pumpAndSettle();
 
         expect(find.byType(AlertDialog), findsOneWidget);

--- a/test/weather_panel_widget_test.dart
+++ b/test/weather_panel_widget_test.dart
@@ -83,8 +83,11 @@ void main() {
         await tester.tap(find.text('Reload'));
         // 非同期処理を開始(Reloadボタン押下)
         await tester.pump();
+
         // インジケータが表示されているか
         expect(find.byType(CircularProgressIndicator), findsOneWidget);
+
+        // 非同期処理を完了
         completer.complete(weather);
         await tester.pumpAndSettle();
 
@@ -153,7 +156,7 @@ void main() {
           ),
         );
 
-        //  Reloadを押下して描画完了まで待機
+        // 非同期処理を開始(Reloadボタン押下)
         await tester.tap(find.text('Reload'));
         await tester.pump();
 

--- a/test/weather_panel_widget_test.dart
+++ b/test/weather_panel_widget_test.dart
@@ -101,43 +101,44 @@ void main() {
     }
   });
   group(' WeatherPanelの異常テスト', () {
-    testWidgets('エラーダイアログ', (tester) async {
-      setUp(tester);
-      final location = Location(
-        area: 'tokyo',
-        date: DateTime.parse('2020-04-24T12:09:46+09:00'),
-      );
+    final location = Location(
+      area: 'tokyo',
+      date: DateTime.parse('2020-04-24T12:09:46+09:00'),
+    );
 
-      final errorCases = [
-        (InvalidParameterException(), '「${location.area}」は無効な地域名です'),
-        (
-          UnknownException(),
-          '予期せぬエラーが発生しております。'
-              '時間を置いてもエラーが発生する場合はお問い合わせお願いいたします。'
-        ),
-        (
-          InvalidResponseException(),
-          '予期せぬエラーが発生しております。'
-              '時間を置いてもエラーが発生する場合はお問い合わせお願いいたします。'
-        ),
-        (
-          JsonDecodeException(),
-          '予期せぬエラーが発生しております。'
-              '時間を置いてもエラーが発生する場合はお問い合わせお願いいたします。'
-        ),
-        (
-          CheckedFromJsonException({}, null, '', null),
-          '予期しない天気が取得されました。'
-              '時間を置いてもエラーが発生する場合はお問い合わせお願いいたします。'
-        ),
-        (
-          Exception(),
-          '予期しない天気が取得されました。'
-              '時間を置いてもエラーが発生する場合はお問い合わせお願いいたします。'
-        ),
-      ];
+    final errorCases = [
+      (InvalidParameterException(), '「${location.area}」は無効な地域名です'),
+      (
+        UnknownException(),
+        '予期せぬエラーが発生しております。'
+            '時間を置いてもエラーが発生する場合はお問い合わせお願いいたします。'
+      ),
+      (
+        InvalidResponseException(),
+        '予期せぬエラーが発生しております。'
+            '時間を置いてもエラーが発生する場合はお問い合わせお願いいたします。'
+      ),
+      (
+        JsonDecodeException(),
+        '予期せぬエラーが発生しております。'
+            '時間を置いてもエラーが発生する場合はお問い合わせお願いいたします。'
+      ),
+      (
+        CheckedFromJsonException({}, null, '', null),
+        '予期しない天気が取得されました。'
+            '時間を置いてもエラーが発生する場合はお問い合わせお願いいたします。'
+      ),
+      (
+        Exception(),
+        '予期しない天気が取得されました。'
+            '時間を置いてもエラーが発生する場合はお問い合わせお願いいたします。'
+      ),
+    ];
 
-      for (final (exception, errorMessage) in errorCases) {
+    for (final (exception, errorMessage) in errorCases) {
+      testWidgets('エラーダイアログ', (tester) async {
+        setUp(tester);
+
         final completer = Completer<Weather>();
         when(mockWeatherRepository.fetchWeather(any)).thenAnswer(
           (_) => completer.future,
@@ -181,7 +182,7 @@ void main() {
         expect(find.byType(AlertDialog), findsNothing);
         // インジケータが消えているか
         expect(find.byType(CircularProgressIndicator), findsNothing);
-      }
-    });
+      });
+    }
   });
 }

--- a/test/weather_panel_widget_test.dart
+++ b/test/weather_panel_widget_test.dart
@@ -100,7 +100,7 @@ void main() {
       final errorCases = [
         (InvalidParameterException(), '「${location.area}」は無効な地域名です'),
         (
-          UnkownException(),
+          UnknownException(),
           '予期せぬエラーが発生しております。'
               '時間を置いてもエラーが発生する場合はお問い合わせお願いいたします。'
         ),

--- a/test/weather_panel_widget_test.dart
+++ b/test/weather_panel_widget_test.dart
@@ -80,8 +80,8 @@ void main() {
           ),
         );
 
-        await tester.tap(find.text('Reload'));
         // 非同期処理を開始(Reloadボタン押下)
+        await tester.tap(find.text('Reload'));
         await tester.pump();
 
         // インジケータが表示されているか

--- a/test/weather_panel_widget_test.dart
+++ b/test/weather_panel_widget_test.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_svg/svg.dart';
@@ -61,8 +63,9 @@ void main() {
         );
         setUp(tester);
 
+        final completer = Completer<Weather>();
         when(mockWeatherRepository.fetchWeather(any)).thenAnswer(
-          (_) async => weather,
+          (_) => completer.future,
         );
 
         await tester.pumpWidget(
@@ -78,6 +81,11 @@ void main() {
         );
 
         await tester.tap(find.text('Reload'));
+        // 非同期処理を開始(Reloadボタン押下)
+        await tester.pump();
+        // インジケータが表示されているか
+        expect(find.byType(CircularProgressIndicator), findsOneWidget);
+        completer.complete(weather);
         await tester.pumpAndSettle();
 
         final asset = SvgPicture.asset(svg);

--- a/test/weather_panel_widget_test.mocks.dart
+++ b/test/weather_panel_widget_test.mocks.dart
@@ -3,7 +3,9 @@
 // Do not manually edit this file.
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
-import 'package:flutter_training/weather/location.dart' as _i4;
+import 'dart:async' as _i4;
+
+import 'package:flutter_training/weather/location.dart' as _i5;
 import 'package:flutter_training/weather/weather.dart' as _i2;
 import 'package:flutter_training/weather/weather_repository.dart' as _i3;
 import 'package:mockito/mockito.dart' as _i1;
@@ -40,17 +42,18 @@ class MockWeatherRepository extends _i1.Mock implements _i3.WeatherRepository {
   }
 
   @override
-  _i2.Weather fetchWeather(_i4.Location? location) => (super.noSuchMethod(
+  _i4.Future<_i2.Weather> fetchWeather(_i5.Location? location) =>
+      (super.noSuchMethod(
         Invocation.method(
           #fetchWeather,
           [location],
         ),
-        returnValue: _FakeWeather_0(
+        returnValue: _i4.Future<_i2.Weather>.value(_FakeWeather_0(
           this,
           Invocation.method(
             #fetchWeather,
             [location],
           ),
-        ),
-      ) as _i2.Weather);
+        )),
+      ) as _i4.Future<_i2.Weather>);
 }

--- a/test/weather_repository_test.dart
+++ b/test/weather_repository_test.dart
@@ -31,7 +31,7 @@ void main() {
   });
 
   group('weatherRepositoryの正常系テスト', () {
-    test('API結果で天気が晴れの場合', () {
+    test('API結果で天気が晴れの場合', () async {
       // Arrange
 
       const result = '''
@@ -41,7 +41,7 @@ void main() {
   "min_temperature":3,
   "date":"2020-04-01T12:00:00+09:00"
 }''';
-      when(mockYumemiWeather.fetchWeather(any)).thenReturn(result);
+      when(mockYumemiWeather.syncFetchWeather(any)).thenReturn(result);
 
       const expected = Weather(
         condition: WeatherCondition.sunny,
@@ -50,7 +50,7 @@ void main() {
       );
 
       // Act
-      final actual = weatherRepository.fetchWeather(location);
+      final actual = await weatherRepository.fetchWeather(location);
 
       // Assert
       expect(
@@ -64,10 +64,11 @@ void main() {
     test('想定外の形式・値APIレスポンスが返ってきた場合にJsonDecodeExceptionが発生する', () {
       // Arrange
       const result = '';
-      when(mockYumemiWeather.fetchWeather(any)).thenReturn(result);
+      when(mockYumemiWeather.syncFetchWeather(any)).thenReturn(result);
 
       // Act
-      Weather actual() => weatherRepository.fetchWeather(location);
+      Future<Weather> actual() async =>
+          weatherRepository.fetchWeather(location);
 
       // Assert
       expect(
@@ -78,11 +79,12 @@ void main() {
 
     test('InvalidParameterError が発生した時に InvalidParameterException をキャッチ', () {
       // Arrange
-      when(mockYumemiWeather.fetchWeather(any))
+      when(mockYumemiWeather.syncFetchWeather(any))
           .thenThrow(YumemiWeatherError.invalidParameter);
 
       // Act
-      Weather actual() => weatherRepository.fetchWeather(location);
+      Future<Weather> actual() async =>
+          weatherRepository.fetchWeather(location);
 
       // Assert
       expect(
@@ -93,11 +95,12 @@ void main() {
 
     test('UnkownError が発生した時に UnkownException をキャッチ', () {
       // Arrange
-      when(mockYumemiWeather.fetchWeather(any))
+      when(mockYumemiWeather.syncFetchWeather(any))
           .thenThrow(YumemiWeatherError.unknown);
 
       // Act
-      Weather actual() => weatherRepository.fetchWeather(location);
+      Future<Weather> actual() async =>
+          weatherRepository.fetchWeather(location);
 
       // Assert
       expect(

--- a/test/weather_repository_test.dart
+++ b/test/weather_repository_test.dart
@@ -105,7 +105,7 @@ void main() {
       // Assert
       expect(
         actual,
-        throwsA(const TypeMatcher<UnkownException>()),
+        throwsA(const TypeMatcher<UnknownException>()),
       );
     });
   });


### PR DESCRIPTION
## 課題

close #12 

## 対応箇所

<!--
課題のどこに対応したか１つ１つ確認しましょう。
-->

- [x] 使用する API を fetchWeather() から syncFetchWeather() に変更する
- [x] API の処理が戻るまで CircularProgressIndicator を表示する
- [x] テストの更新
- [x] APIレスポンス待機中のインジケータ表示テスト（正常系）実装

## 動作

<!--
画像や動画を添付しましょう。
動作に変更なければ、必要ありません。
-->

| expected | actual |
|----------|--------|
| <img src="https://github.com/yumemi-ymorii/flutter-training/assets/126639057/0a6bead1-62df-4af6-8fac-5e3600daee9a" width="300" />    | <img src="https://github.com/yumemi-ymorii/flutter-training/assets/126639057/f551aa7d-c3d4-45d1-a995-bb5f7d69063f" width="300" />   |

